### PR TITLE
Correct the Django dependency

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -4,7 +4,7 @@ parts +=
   console_scripts
 
 [versions]
-django = 1.4
+Django = 1.4
 zest.releaser = 3.34
 
 [console_scripts]
@@ -12,4 +12,3 @@ recipe = zc.recipe.egg
 interpreter = python
 eggs =
     zest.releaser
-

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(name='djangorecipe',
       install_requires=[
         'zc.buildout',
         'zc.recipe.egg',
-        'django',
+        'Django',
       ],
       entry_points="""
       # -*- Entry points: -*-


### PR DESCRIPTION
Hoi Roland,

I have a fix for a problem that not many people might encounter, but can be quite confusing none the less. :)

Buildout failed because it couldn't find 'django'.. Turns out 'Django' is the correct package name. PyPI is case-insensitive, but self-hosted package indices might not be!
