### PR TITLE
Enhancement: Allow initialization code to be added to control-script

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,11 @@ control-script
   equivalent of the `manage.py` Django normally creates. By default it
   uses the name of the section (the part between the `[ ]`).
 
+initialization
+  Specify some Python initialization code to be inserted into the
+  `control-script`. This is very limited. In particular, be aware that
+  leading whitespace is stripped from the code given.
+
 wsgi
   An extra script is generated in the bin folder when this is set to
   `true`. This can be used with mod_wsgi to deploy the project. The
@@ -240,3 +245,34 @@ example as a starting point::
          ErrorLog        /var/log/apache2/my.rocking.server/error.log
          WSGIScriptAlias / /path/to/buildout/bin/django.wsgi
   </VirtualHost>
+
+Generating a control script for PyDev
+=====================================
+
+Running Django with auto-reload in PyDev requires adding a small snippet
+of code::
+
+  import pydevd
+  pydevd.patch_django_autoreload(patch_remote_debugger=False, patch_show_console=True)
+
+just before the `if __name__ == "__main__":` in the `manage.py` module
+(or in this case the control script that is generated). This example
+buildout generates two control scripts: one for command-line usage and
+one for PyDev, with the required snippet, using the recipe's
+`initialization` option::
+
+  [buildout]
+  parts = django pydev
+  eggs =
+    mock
+
+  [django]
+  recipe = djangorecipe
+  eggs = ${buildout:eggs}
+  project = dummyshop
+
+  [pydev]
+  <= django
+  initialization =
+    import pydevd
+    pydevd.patch_django_autoreload(patch_remote_debugger=False, patch_show_console=True)

--- a/src/djangorecipe/recipe.py
+++ b/src/djangorecipe/recipe.py
@@ -39,6 +39,8 @@ class Recipe(object):
         else:
             options.setdefault('extra-paths', options.get('pythonpath', ''))
 
+        options.setdefault('initialization', '')
+
         # mod_wsgi support script
         options.setdefault('wsgi', 'false')
         options.setdefault('fcgi', 'false')
@@ -82,8 +84,8 @@ class Recipe(object):
               'djangorecipe.manage', 'main')],
             ws, self.options['executable'], self.options['bin-directory'],
             extra_paths=extra_paths,
-            arguments="'%s.%s'" % (project,
-                                   self.options['settings']))
+            arguments="'%s.%s'" % (project, self.options['settings']),
+            initialization=self.options['initialization'])
 
     def create_test_runner(self, extra_paths, working_set):
         apps = self.options.get('test', '').split()

--- a/src/djangorecipe/tests/tests.py
+++ b/src/djangorecipe/tests/tests.py
@@ -246,6 +246,13 @@ class TestRecipeScripts(BaseTestRecipe):
         self.assertTrue("djangorecipe.manage.main('spameggs.development')"
                         in open(manage).read())
 
+    def test_create_manage_script_with_initialization(self):
+        manage = os.path.join(self.bin_dir, 'django')
+        self.recipe.options['initialization'] = 'import os\nassert True'
+        self.recipe.create_manage_script([], [])
+        self.assertTrue('import os\nassert True\n\nimport djangorecipe'
+                        in open(manage).read())
+
     def test_create_wsgi_script_projectegg(self):
         # When a projectegg is specified, then the egg specified
         # should get used as the project in the wsgi script.


### PR DESCRIPTION
I'm using [Pydev](http://pydev.org/index.html) with its Django support for my Django project. Running [Django with auto-reload](http://pydev.org/manual_adv_django.html#PyDevDjango-RunDjangowithautoreload) in Pydev requires adding a small snippet of code

```
import pydevd
pydevd.patch_django_autoreload(patch_remote_debugger=False, patch_show_console=True)
```

just before the `if _name_ == "_main_":` in the manage.py module (or in this case the control-script that is generated).

If Djangorecipe provides an `initialization` option, which would get passed as a parameter directly to `zc.buildout.easy_install.scripts`, creating a control-script for Pydev would be dead-simple. Something like the following could then be used to generate two control-scripts, one for command-line usage and one for Pydev:

```
...
[django]
recipe = djangorecipe
project = dummyshop
eggs = ${buildout:eggs}

[pydev]
<= django
initialization =
    import pydevd
    pydevd.patch_django_autoreload(patch_remote_debugger=False, patch_show_console=True)
```

I can submit a pull request if this enhancement gets accepted.
