### PR TITLE
Django in versions is no longer 'django' but 'Django'

### DIFF
--- a/src/djangorecipe/recipe.py
+++ b/src/djangorecipe/recipe.py
@@ -114,7 +114,10 @@ class Recipe(object):
         version = None
         b_versions = self.buildout.get('versions')
         if b_versions:
-            django_version = b_versions.get('django')
+            django_version = (
+                b_versions.get('django') or
+                b_versions.get('Django')
+            )
             if django_version:
                 version_re = re.compile("\d+\.\d+")
                 match = version_re.match(django_version)


### PR DESCRIPTION
Hi, 

I have a problem running the recipe. In my project https://github.com/kiberpipa/library/commit/f93cedef3182b9b0af5d76653da55607fba002e7 .

The problem is that I get a version conflict. Because djangorecipe just checks if there is `django` but not `Django`. But in the version file there is just a `Django` entry.
Checking for both `Django` and `django` seems to fix the problem.
