### PR TITLE
Ignore the eggs directory in project root folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ parts
 src/djangorecipe.egg-info
 .coverage
 htmlcov
+/eggs


### PR DESCRIPTION
Ignore the eggs folder (created by buildout).
