### PR TITLE
Project settings organization more clear.

### DIFF
--- a/src/djangorecipe/boilerplate.py
+++ b/src/djangorecipe/boilerplate.py
@@ -31,8 +31,9 @@ from %(project)s.settings.base import *
 
 development_settings = """
 from %(project)s.settings.base import *
-DEBUG=True
-TEMPLATE_DEBUG=DEBUG
+
+DEBUG = True
+TEMPLATE_DEBUG = DEBUG
 """
 
 urls_template = """

--- a/src/djangorecipe/boilerplate.py
+++ b/src/djangorecipe/boilerplate.py
@@ -26,11 +26,11 @@ import %(module_name)s
 }
 
 production_settings = """
-from %(project)s.settings import *
+from %(project)s.settings.base import *
 """
 
 development_settings = """
-from %(project)s.settings import *
+from %(project)s.settings.base import *
 DEBUG=True
 TEMPLATE_DEBUG=DEBUG
 """
@@ -168,6 +168,8 @@ settings_template_1_3 = """
 
 import os
 
+PROJECT_ROOT = os.path.join(os.path.dirname(__file__), os.path.pardir)
+
 ADMINS = (
     # ('Your Name', 'your_email@example.com'),
 )
@@ -271,7 +273,7 @@ TEMPLATE_DIRS = (
     # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
     # Always use forward slashes, even on Windows.
     # Don't forget to use absolute paths, not relative paths.
-    os.path.join(os.path.dirname(__file__), "templates"),
+    os.path.join(PROJECT_ROOT, 'templates'),
 )
 
 INSTALLED_APPS = (
@@ -317,14 +319,14 @@ versions = {
         'urls': urls_template,
         'production_settings': production_settings,
         'development_settings': development_settings,
-        },
+    },
     '1.3': {
         'settings': settings_template_1_3,
         'urls': urls_template,
         'production_settings': production_settings,
         'development_settings': development_settings,
-        },
-    }
+    },
+}
 
 # Easy way to specify the newest Django version.
 versions['Newest'] = versions['1.3']

--- a/src/djangorecipe/recipe.py
+++ b/src/djangorecipe/recipe.py
@@ -107,7 +107,7 @@ class Recipe(object):
             return []
 
     def create_project(self, project_dir):
-        os.makedirs(project_dir)
+        os.makedirs(os.path.join(project_dir, 'settings'))
 
         # Find the current Django versions in the buildout versions.
         # Assume the newest Django when no version is found.
@@ -129,11 +129,11 @@ class Recipe(object):
         template_vars.update(self.options)
 
         self.create_file(
-            os.path.join(project_dir, 'development.py'),
+            os.path.join(project_dir, 'settings', 'development.py'),
             config['development_settings'], template_vars)
 
         self.create_file(
-            os.path.join(project_dir, 'production.py'),
+            os.path.join(project_dir, 'settings', 'production.py'),
             config['production_settings'], template_vars)
 
         self.create_file(
@@ -141,7 +141,7 @@ class Recipe(object):
             config['urls'], template_vars)
 
         self.create_file(
-            os.path.join(project_dir, 'settings.py'),
+            os.path.join(project_dir, 'settings', 'base.py'),
             config['settings'], template_vars)
 
         # Create the media and templates directories for our

--- a/src/djangorecipe/tests/tests.py
+++ b/src/djangorecipe/tests/tests.py
@@ -142,15 +142,19 @@ class TestRecipe(BaseTestRecipe):
         # If a project does not exist already the recipe will create
         # one.
         project_dir = os.path.join(self.buildout_dir, 'project')
+        settings_dir = os.path.join(project_dir, 'settings')
         self.recipe.create_project(project_dir)
 
-        # This should have create a project directory
+        # This should have create project directories.
         self.assertTrue(os.path.exists(project_dir))
-        # With this directory we should have a list of files.
-        for f in ('settings.py', 'development.py', 'production.py',
-                  '__init__.py', 'urls.py', 'media', 'templates'):
+        self.assertTrue(os.path.exists(settings_dir))
+        # With this directories we should have a list of files.
+        for f in ('__init__.py', 'urls.py', 'media', 'templates'):
             self.assertTrue(
                 os.path.exists(os.path.join(project_dir, f)))
+        for f in ('base.py', 'development.py', 'production.py'):
+            self.assertTrue(
+                os.path.exists(os.path.join(settings_dir, f)))
 
 
 class TestRecipeScripts(BaseTestRecipe):
@@ -326,12 +330,13 @@ class TestBoilerplate(BaseTestRecipe):
         """Test the default boilerplate."""
 
         project_dir = os.path.join(self.buildout_dir, 'project')
+        settings_dir = os.path.join(project_dir, 'settings')
 
         secret = '$55upfci7a#gi@&e9o1-hb*k+f$3+(&b$j=cn67h#22*0%-bj0'
         self.recipe.generate_secret = lambda: secret
 
         self.recipe.create_project(project_dir)
-        settings = open(os.path.join(project_dir, 'settings.py')).read()
+        settings = open(os.path.join(settings_dir, 'base.py')).read()
         settings_dict = {'project': self.recipe.options['project'],
                          'secret': secret,
                          'urlconf': self.recipe.options['urlconf'],
@@ -352,8 +357,9 @@ class TestBoilerplate(BaseTestRecipe):
         recipe.generate_secret = lambda: secret
 
         project_dir = os.path.join(self.buildout_dir, 'project')
+        settings_dir = os.path.join(project_dir, 'settings')
         recipe.create_project(project_dir)
-        settings = open(os.path.join(project_dir, 'settings.py')).read()
+        settings = open(os.path.join(settings_dir, 'base.py')).read()
         settings_dict = {'project': self.recipe.options['project'],
                          'secret': secret,
                          'urlconf': self.recipe.options['urlconf'],


### PR DESCRIPTION
Hello Roland,

First, thank you for the nice djangorecipe. I find it very useful and it's great to know it stills in continuous development :)

I know it's just a personal matter, but usually I find more tidy in a Django project to have a `settings` directory containing the settings files, since almost all developers use to have different settings for different environments.

For this, I made a little modification to the djangorecipe. Basically, instead of creating the three settings files `settings.py`, `development.py` and `production.py`, now creates a `settings` directory which contains those files. I renamed `settings.py` to `base.py` to be more clear.

I also reviewed the unit tests related to this changes, adapting them to the new behavior.

I made this pull request to share the changes with you, just for your interest. So, feel free to include it in the official djangorecipe if you like it or to refuse if you want to keep the current schema.

Anyway, thanks!

EDIT: I created also a `PROJECT_ROOT` variable in the main settings template, since it's a very common thing and makes the paths in code more easy.