### PR TITLE
Set `sys.argv` to keep the `'test' in sys.argv` convention working.

### DIFF
--- a/src/djangorecipe/test.py
+++ b/src/djangorecipe/test.py
@@ -1,9 +1,10 @@
 import os
+import sys
 
 from django.core import management
 
 
 def main(settings_file, *apps):
-    argv = ['test', 'test'] + list(apps)
+    sys.argv[1:] = ['test'] + list(apps)
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', settings_file)
-    management.execute_from_command_line(argv=argv)
+    management.execute_from_command_line(argv=sys.argv)


### PR DESCRIPTION
Some `settings.py` configurations test for the `'test'` command line argument to switch settings for tests; by setting `sys.argv` directly the `bin/test` command cooperates with those.

This patch is against the `django1.5` branch.
