### PR TITLE
Add a setting to append additional code to wsgi/fcgi deployment scripts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,11 @@ fcgi
   Like `wsgi` this creates an extra script within the bin folder. This
   script can be used with an FCGI deployment.
 
+deploy_script_extra
+  For `wsgi` and `fcgi` deployment scripts, allow extra content to be appended
+  to the output files. This can be useful when wrapping the application
+  with a service such as New Relic.
+
 test
   If you want a script in the bin folder to run all the tests for a
   specific set of apps this is the option you would use. Set this to

--- a/src/djangorecipe/recipe.py
+++ b/src/djangorecipe/recipe.py
@@ -41,6 +41,7 @@ class Recipe(object):
             options.setdefault('extra-paths', options.get('pythonpath', ''))
 
         options.setdefault('initialization', '')
+        options.setdefault('deploy_script_extra', '')
 
         # mod_wsgi support script
         options.setdefault('wsgi', 'false')
@@ -160,7 +161,8 @@ class Recipe(object):
         for protocol in ('wsgi', 'fcgi'):
             zc.buildout.easy_install.script_template = \
                 zc.buildout.easy_install.script_header + \
-                    script_template[protocol]
+                    script_template[protocol] + \
+                        self.options['deploy_script_extra']
             if self.options.get(protocol, '').lower() == 'true':
                 project = self.options.get('projectegg',
                                            self.options['project'])

--- a/src/djangorecipe/tests/tests.py
+++ b/src/djangorecipe/tests/tests.py
@@ -226,6 +226,16 @@ class TestRecipeScripts(BaseTestRecipe):
 
         self.assertTrue("logfile='/foo'" in contents)
 
+    def test_deploy_script_extra(self):
+        extra_val = '#--deploy_script_extra--'
+        self.recipe.options['wsgi'] = 'true'
+        self.recipe.options['deploy_script_extra'] = extra_val
+        self.recipe.make_scripts([], [])
+
+        wsgi_script = os.path.join(self.bin_dir, 'django.wsgi')
+        contents = open(wsgi_script).read()
+        self.assertTrue(extra_val in contents)
+
     @mock.patch('zc.buildout.easy_install.scripts',
                 return_value=['some-path'])
     def test_make_protocol_scripts_return_value(self, scripts):


### PR DESCRIPTION
The existing `initialization` setting is handy for adding extra code to the wsgi files such as for loading celery, but for other purposes like New Relic integration, there's no way to wrap the `application` object with an agent. This change creates a new `deploy_script_extra` setting that appends its value to the .wsgi/.fcgi files.

Example usage:

```
deploy_script_extra =
    import newrelic.agent
    newrelic.agent.initialize('/etc/newrelic.ini', 'app')
    application = newrelic.agent.WSGIApplicationWrapper(application)
```
