### PR TITLE
Respect buildout's relative-paths.

### DIFF
--- a/src/djangorecipe/recipe.py
+++ b/src/djangorecipe/recipe.py
@@ -48,6 +48,16 @@ class Recipe(object):
         options.setdefault('wsgilog', '')
         options.setdefault('logfile', '')
 
+        # respect relative-paths (from zc.recipe.egg)
+        relative_paths = options.get(
+            'relative-paths', buildout['buildout'].get('relative-paths', 'false'))
+        if relative_paths == 'true':
+            options['buildout-directory'] = buildout['buildout']['directory']
+            self._relative_paths = options['buildout-directory']
+        else:
+            self._relative_paths = ''
+            assert relative_paths == 'false'
+
     def install(self):
         base_dir = self.buildout['buildout']['directory']
 
@@ -85,6 +95,7 @@ class Recipe(object):
               'djangorecipe.manage', 'main')],
             ws, sys.executable, self.options['bin-directory'],
             extra_paths=extra_paths,
+            relative_paths=self._relative_paths,
             arguments="'%s.%s'" % (project, self.options['settings']),
             initialization=self.options['initialization'])
 
@@ -98,6 +109,7 @@ class Recipe(object):
                 working_set, sys.executable,
                 self.options['bin-directory'],
                 extra_paths=extra_paths,
+                relative_paths=self._relative_paths,
                 arguments="'%s.%s', %s" % (
                     self.options['project'],
                     self.options['settings'],
@@ -171,6 +183,7 @@ class Recipe(object):
                         sys.executable,
                         self.options['bin-directory'],
                         extra_paths=extra_paths,
+                        relative_paths=self._relative_paths,
                         arguments="'%s.%s', logfile='%s'" % (
                             project, self.options['settings'],
                             self.options.get('logfile')),

--- a/src/djangorecipe/tests/tests.py
+++ b/src/djangorecipe/tests/tests.py
@@ -319,6 +319,47 @@ class TestTesTRunner(BaseTestRecipe):
         self.assertTrue('import os\nassert True\n\nimport djangorecipe'
                         in open(testrunner).read())
 
+    def test_relative_paths_default(self):
+        self.recipe.options['wsgi'] = 'true'
+
+        self.recipe.make_scripts([], [])
+        self.recipe.create_manage_script([], [])
+
+        manage = os.path.join(self.bin_dir, 'django')
+        wsgi_script = os.path.join(self.bin_dir, 'django.wsgi')
+
+        expected = base = 'base = os.path.dirname(os.path.abspath(os.path.realpath(__file__)))'
+        self.assertFalse(expected in open(manage).read())
+        self.assertFalse(expected in open(wsgi_script).read())
+
+    def test_relative_paths_true(self):
+        recipe = Recipe({
+                'buildout': {
+                    'eggs-directory': self.eggs_dir,
+                    'develop-eggs-directory': self.develop_eggs_dir,
+                    'python': 'python-version',
+                    'bin-directory': self.bin_dir,
+                    'parts-directory': self.parts_dir,
+                    'directory': self.buildout_dir,
+                    'find-links': '',
+                    'allow-hosts': '',
+                    'develop': '.',
+                    'relative-paths': 'true'
+                    },
+                'python-version': {'executable': sys.executable}},
+                             'django',
+                             {'recipe': 'djangorecipe',
+                              'wsgi': 'true'})
+        recipe.make_scripts([], [])
+        recipe.create_manage_script([], [])
+
+        manage = os.path.join(self.bin_dir, 'django')
+        wsgi_script = os.path.join(self.bin_dir, 'django.wsgi')
+
+        expected = base = 'base = os.path.dirname(os.path.abspath(os.path.realpath(__file__)))'
+        self.assertTrue(expected in open(manage).read())
+        self.assertTrue(expected in open(wsgi_script).read())
+
 
 class TestBoilerplate(BaseTestRecipe):
 


### PR DESCRIPTION
Avoid absolute paths in the generated scipts.
