### PR TITLE
Convert test.py to use the Django 1.4+ execute_from_command_line.

### DIFF
--- a/src/djangorecipe/test.py
+++ b/src/djangorecipe/test.py
@@ -1,7 +1,10 @@
+import os
+
+import django
 from django.core import management
 
 
-def main(settings_file, *apps):
+def main_pre_14(settings_file, *apps):
     argv = ['test', 'test'] + list(apps)
     try:
         settings = __import__(settings_file)
@@ -17,3 +20,16 @@ def main(settings_file, *apps):
         sys.exit(1)
 
     management.execute_manager(settings, argv=argv)
+
+
+def main_14(settings_file, *apps):
+    argv = ['test', 'test'] + list(apps)
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', settings_file)
+    management.execute_from_command_line(argv)
+
+
+def main(settings_file, *apps):
+    if django.VERSION[0:2] >= (1, 4):
+        main_14(settings_file, *apps)
+    else:
+        main_pre_14(settings_file, *apps)


### PR DESCRIPTION
execute_manager deprecated in Django 1.4 and removed in 1.6. Use
the same strategy as manage.py to determine whether to use
execute_manager or execute_from_command_line based upon the Django
version.

https://docs.djangoproject.com/en/1.4/releases/1.4/#django-core-management-execute-manager
