### PR TITLE
new variable 'management_custom_args'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ Changes
   Useful for instance for a cloud hoster where you need to wrap your wsgi
   application object in a custom call.
 
+- Added ``dotted-settings-path`` option. Useful when you want to specify a
+  custom settings path to be used by the ``manage.main()`` command.
+
 
 1.8 (2014-05-27)
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,10 @@ secret
   The secret to use for the `settings.py`, it generates a random
   string by default.
 
+dotted-settings-path
+  Use this option to specify a custom settings path to be used by the
+  `manage.main()` command.
+
 
 Another example
 -----------------
@@ -142,6 +146,7 @@ The next example shows you how to use some more of the options::
   test =
     someapp
     anotherapp
+  dotted-settings-path = src.project.settings
 
 Example using .pth files
 -------------------------

--- a/src/djangorecipe/recipe.py
+++ b/src/djangorecipe/recipe.py
@@ -91,15 +91,9 @@ class Recipe(object):
     def create_manage_script(self, extra_paths, ws):
         project = self.options.get('projectegg', self.options['project'])
 
-        # By default, it's "project.settings".
-        default_arguments = '%s.%s' % (project,
-                                       self.options['settings'])
-
-        # Setting the 'management_custom_args' field allows you to have
-        # custom arguments when calling the management.main(), which might
-        # be useful to projects with poor folder structure.
-        arguments = self.options.get('management_custom_args',
-                                     default_arguments)
+        settings_path = '%s.%s' % (project, self.options['settings'])
+        arguments = self.options.get('dotted-settings-path', 
+                                     settings_path)
 
         return zc.buildout.easy_install.scripts(
             [(self.options.get('control-script', self.name),


### PR DESCRIPTION
First of all, thank you for this useful piece of code. We've been using and it has been amazing so far, but we needed something else and we would like to share with you.

This new variable allows you to have specific arguments when calling the management.main() method. This solves some problems when you have poor project structure, like the problem I had in the past days, and the only solution for that, at the moment, was forking and allow a custom option like this.

Obviously, this might not make sense to you guys, but it doesn't interfere with your builds anyway and it's only another option we will have.

Also, this is my first PR and I'm glad I can finally contribute with something to the open-source world.
