### PR TITLE
Add boilerplate for Django 1.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ endif
 ifeq ($(DJANGO_VERSION),1.6)
 	bin/buildout -c buildout16.cfg
 endif
+ifeq ($(DJANGO_VERSION),1.7)
+	bin/buildout -c buildout17.cfg
+endif
 
 test:
 	bin/test

--- a/buildout17.cfg
+++ b/buildout17.cfg
@@ -1,0 +1,8 @@
+[buildout]
+extends = buildout.cfg
+find-links =
+    https://www.djangoproject.com/download/1.7/tarball/#egg=Django-1.7
+
+
+[versions]
+Django = 1.7

--- a/src/djangorecipe/boilerplate.py
+++ b/src/djangorecipe/boilerplate.py
@@ -50,6 +50,20 @@ if settings.DEBUG:
 
 """
 
+urls_template_1_7 = """
+from django.conf.urls import patterns, include, url
+from django.contrib import admin
+
+urlpatterns = patterns('',
+    # Examples:
+    # url(r'^$', '%(project)s.views.home', name='home'),
+    # url(r'^blog/', include('blog.urls')),
+
+    url(r'^admin/', include(admin.site.urls)),
+)
+"""
+
+
 settings_template_1_2 = """
 # Django settings for %(project)s project.
 
@@ -299,6 +313,91 @@ LOGGING = {
 }
 """
 
+settings_template_1_7 = """
+# Django settings for %(project)s project.
+#
+# For more information on this file, see
+# https://docs.djangoproject.com/en/1.7/topics/settings/
+#
+# For the full list of settings and their values, see
+# https://docs.djangoproject.com/en/1.7/ref/settings/
+
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+import os
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+
+
+# Quick-start development settings - unsuitable for production
+# See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = '%(secret)s'
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+TEMPLATE_DEBUG = True
+
+ALLOWED_HOSTS = []
+
+
+# Application definition
+
+INSTALLED_APPS = (
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+)
+
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+)
+
+ROOT_URLCONF = '%(urlconf)s'
+
+WSGI_APPLICATION = '%(project)s.wsgi.application'
+
+
+# Database
+# https://docs.djangoproject.com/en/1.7/ref/settings/#databases
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    }
+}
+
+# Internationalization
+# https://docs.djangoproject.com/en/1.7/topics/i18n/
+
+LANGUAGE_CODE = 'en-us'
+
+TIME_ZONE = 'UTC'
+
+USE_I18N = True
+
+USE_L10N = True
+
+USE_TZ = True
+
+
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/1.7/howto/static-files/
+
+STATIC_URL = '/static/'
+"""
+
+
 versions = {
     '1.2': {
         'settings': settings_template_1_2,
@@ -312,7 +411,13 @@ versions = {
         'production_settings': production_settings,
         'development_settings': development_settings,
         },
+    '1.7': {
+        'settings': settings_template_1_7,
+        'urls': urls_template_1_7,
+        'production_settings': production_settings,
+        'development_settings': development_settings,
+        },
     }
 
 # Easy way to specify the newest Django version.
-versions['Newest'] = versions['1.3']
+versions['Newest'] = versions['1.7']

--- a/src/djangorecipe/boilerplate.py
+++ b/src/djangorecipe/boilerplate.py
@@ -398,6 +398,21 @@ STATIC_URL = '/static/'
 """
 
 
+wsgi_template = """
+# WSGI config for %(project)s project.
+#
+# It exposes the WSGI callable as a module-level variable named ``application``.
+#
+# For more information on this file, see
+# https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/
+
+import os
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "%(project)s.settings")
+
+from django.core.wsgi import get_wsgi_application
+application = get_wsgi_application()
+"""
+
 versions = {
     '1.2': {
         'settings': settings_template_1_2,
@@ -414,6 +429,7 @@ versions = {
     '1.7': {
         'settings': settings_template_1_7,
         'urls': urls_template_1_7,
+        'wsgi': wsgi_template,
         'production_settings': production_settings,
         'development_settings': development_settings,
         },

--- a/src/djangorecipe/recipe.py
+++ b/src/djangorecipe/recipe.py
@@ -161,6 +161,11 @@ class Recipe(object):
             os.path.join(project_dir, 'settings.py'),
             config['settings'], template_vars)
 
+        if version == '1.7':
+            self.create_file(
+                os.path.join(project_dir, 'wsgi.py'),
+                config['wsgi'], template_vars)
+
         # Create the media and templates directories for our
         # project
         os.mkdir(os.path.join(project_dir, 'media'))

--- a/src/djangorecipe/tests/tests.py
+++ b/src/djangorecipe/tests/tests.py
@@ -401,3 +401,26 @@ class TestBoilerplate(BaseTestRecipe):
 
         self.assertEqual(versions['1.2']['settings'] % settings_dict,
                           settings)
+
+    def test_boilerplate_1_7(self):
+        """Test the boilerplate for django 1.7."""
+
+        recipe_args = copy.deepcopy(self.recipe_initialisation)
+
+        recipe_args[0]['versions'] = {'django': '1.7.4'}
+        recipe = Recipe(*recipe_args)
+
+        secret = '$55upfci7a#gi@&e9o1-hb*k+f$3+(&b$j=cn67h#22*0%-bj0'
+        recipe.generate_secret = lambda: secret
+
+        project_dir = os.path.join(self.buildout_dir, 'project')
+        recipe.create_project(project_dir)
+        settings = open(os.path.join(project_dir, 'settings.py')).read()
+        settings_dict = {'project': self.recipe.options['project'],
+                         'secret': secret,
+                         'urlconf': self.recipe.options['urlconf'],
+                         }
+        from djangorecipe.boilerplate import versions
+
+        self.assertEqual(versions['1.7']['settings'] % settings_dict,
+                          settings)


### PR DESCRIPTION
Django 1.7 has changed enough to require different boilerplate.  Here's a PR for that.