### PR TITLE
Working around new gunicorn situation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,11 +21,29 @@ Changes
 - We aim at django 1.7 and 1.8 now. Django 1.4 still works, (except that that
   one doesn't have a good startproject command).
 
+- Gunicorn doesn't come with the django manage.py integration, so ``bin/django
+  run_gunicorn`` doesn't work anymore. If you add ``script-entrypoints =
+  gunicorn`` to the configuration, we generate a ``bin/django_env_gunicorn``
+  script that is identical to ``bin/gunicorn``, only with the environment
+  correctly set.
+
+  This way, you can use the wsgi.py script in your project (copy it from the
+  django docs if needed) with ``bin/django_env_gunicorn yourproject/wsgi.py``
+  just like suggested everywhere. This way you can adjust your wsgi file to
+  your liking and run it with gunicorn.
+
+  For other wsgi runners (or programs you want to use with the correct
+  environment set), you can add a full entry point to ``script-entrypoints``,
+  like ``script-entrypoints = gunicorn=gunicorn.app.wsgiapp:run`` would be the
+  full line for gunicorn. Look up the correct entrypoint in the relevant
+  package's ``setup.py``.
+
 - The ``wsgilog`` option has been deprecated, the old apache mod_wsgi script
   hasn't been used for a long time.
 
 - Removed old pth option, previously used for pinax. Pinax uses proper python
   packages since a long time, so it isn't needed anymore.
+
 
 
 1.11 (2014-11-21)

--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,15 @@ settings
   production setup from your development setup. It defaults to
   `development`.
 
+test
+  If you want a script in the bin folder to run all the tests for a
+  specific set of apps this is the option you would use. Set this to
+  the list of app labels which you want to be tested. Normally, it is
+  recommended that you use this option and set it to your project's name.
+
+
+The options below are for older projects or special cases mostly:
+
 dotted-settings-path
   Use this option to specify a custom settings path to be used. By default,
   the ``project`` and ``settings`` option values are concatenated, so for
@@ -73,7 +82,8 @@ initialization
 deploy_script_extra
   In the `wsgi` deployment script, you sometimes need to wrap the application
   in a custom wrapper for some cloud providers. This setting allows extra
-  content to be appended to the end of the wsgi script. The limits described
+  content to be appended to the end of the wsgi script. For instance
+  ``application = some_extra_wrapper(application)``. The limits described
   above for `initialization` also apply here.
 
 wsgi
@@ -85,10 +95,14 @@ wsgi
 wsgi-script
   Use this option if you need to overwrite the name of the script above.
 
-test
-  If you want a script in the bin folder to run all the tests for a
-  specific set of apps this is the option you would use. Set this to
-  the list of app labels which you want to be tested.
+script-entrypoints
+  Entry points you add to here get their scripts created with a prefix of
+  ``django_env_`` (with the default control-script name). They also get the
+  settings environment variable set. At the moment, it is mostly useful for
+  gunicorn, which cannot be run from within the django process anymore. So the
+  script must already be passed the correct settings environment variable. The
+  default is thus ``gunicorn=gunicorn.app.wsgiapp:run``, resulting in a
+  ``django_env_gunicorn``.
 
 testrunner
   This is the name of the testrunner which will be created. It

--- a/README.rst
+++ b/README.rst
@@ -101,8 +101,10 @@ script-entrypoints
   settings environment variable set. At the moment, it is mostly useful for
   gunicorn, which cannot be run from within the django process anymore. So the
   script must already be passed the correct settings environment variable. The
-  default is thus ``gunicorn=gunicorn.app.wsgiapp:run``, resulting in a
-  ``django_env_gunicorn``.
+  correct value would be ``gunicorn=gunicorn.app.wsgiapp:run``, resulting in a
+  ``django_env_gunicorn``. To make it easier, you can provide just
+  ``gunicorn`` as a shorthand notation. (If it is necessary for more wsgi
+  runners, pull requests or bug reports are welcome).
 
 testrunner
   This is the name of the testrunner which will be created. It

--- a/README.rst
+++ b/README.rst
@@ -79,13 +79,6 @@ initialization
   `control-script`. This functionality is very limited. In particular, be
   aware that leading whitespace is stripped from the code given.
 
-deploy_script_extra
-  In the `wsgi` deployment script, you sometimes need to wrap the application
-  in a custom wrapper for some cloud providers. This setting allows extra
-  content to be appended to the end of the wsgi script. For instance
-  ``application = some_extra_wrapper(application)``. The limits described
-  above for `initialization` also apply here.
-
 wsgi
   An extra script is generated in the bin folder when this is set to
   `true`. This is mostly only useful when deploying with apache's
@@ -94,6 +87,13 @@ wsgi
 
 wsgi-script
   Use this option if you need to overwrite the name of the script above.
+
+deploy_script_extra
+  In the `wsgi` deployment script, you sometimes need to wrap the application
+  in a custom wrapper for some cloud providers. This setting allows extra
+  content to be appended to the end of the wsgi script. For instance
+  ``application = some_extra_wrapper(application)``. The limits described
+  above for `initialization` also apply here.
 
 script-entrypoints
   Entry points you add to here get their scripts created with a prefix of

--- a/README.rst
+++ b/README.rst
@@ -94,17 +94,6 @@ testrunner
   This is the name of the testrunner which will be created. It
   defaults to `test`.
 
-All following options only have effect when the project specified by
-the project option has not been created already.
-
-urlconf
-  You can set this to a specific url conf. It will use project.urls by
-  default.
-
-secret
-  The secret to use for the `settings.py`, it generates a random
-  string by default.
-
 
 Another example
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -78,12 +78,12 @@ deploy_script_extra
 
 wsgi
   An extra script is generated in the bin folder when this is set to
-  `true`. This can be used with mod_wsgi to deploy the project. The
-  name of the script is `control-script.wsgi`.
+  `true`. This is mostly only useful when deploying with apache's
+  mod_wsgi. The name of the script is the same as the control script, but with
+  ``.wsgi`` appended. So often it will be ``bin/django.wsgi``.
 
 wsgi-script
-  The name of the wsgi-script that is generated. This can be useful for
-  gunicorn.
+  Use this option if you need to overwrite the name of the script above.
 
 test
   If you want a script in the bin folder to run all the tests for a

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,10 @@ Description
 .. image:: https://secure.travis-ci.org/rvanlaar/djangorecipe.png?branch=master
    :target: http://travis-ci.org/rvanlaar/djangorecipe/
 
+.. image:: https://landscape.io/github/rvanlaar/djangorecipe/master/landscape.svg?style=flat
+   :target: https://landscape.io/github/rvanlaar/djangorecipe/master
+   :alt: Code Health
+
 This buildout recipe can be used to create a setup for Django. It will
 automatically download Django and install it in the buildout's
 sandbox.

--- a/src/djangorecipe/recipe.py
+++ b/src/djangorecipe/recipe.py
@@ -44,8 +44,7 @@ class Recipe(object):
         options.setdefault('extra-paths', '')
         options.setdefault('initialization', '')
         options.setdefault('deploy-script-extra', '')
-        options.setdefault('script-entrypoints',
-                           'gunicorn=gunicorn.app.wsgiapp:run')
+        options.setdefault('script-entrypoints', '')
 
         # mod_wsgi support script
         options.setdefault('wsgi', 'false')
@@ -158,6 +157,9 @@ class Recipe(object):
                        self.options.get('script-entrypoints').splitlines()
                        if entrypoint.strip()]
         for entrypoint in entrypoints:
+            if entrypoint == 'gunicorn':
+                # Shorthand
+                entrypoint = 'gunicorn=gunicorn.app.wsgiapp:run'
             if ':' not in entrypoint or '=' not in entrypoint:
                 raise UserError(
                     "Script entrypoint %s isn't of the form "

--- a/src/djangorecipe/tests/tests.py
+++ b/src/djangorecipe/tests/tests.py
@@ -242,6 +242,41 @@ class TestRecipeScripts(BaseTestRecipe):
                         "logfile='')"
                         in open(wsgi_script).read())
 
+    def test_create_extra_environment_scripts(self):
+        # By default, only gunicorn is configured
+        manage = os.path.join(self.bin_dir, 'django_env_gunicorn')
+        self.recipe.create_extra_environment_scripts([], [])
+        self.assertTrue(os.path.exists(manage))
+
+    def test_create_extra_environment_scripts2(self):
+        # By default, only gunicorn is configured
+        manage = os.path.join(self.bin_dir, 'django_env_gunicorn')
+        self.recipe.create_extra_environment_scripts([], [])
+        self.assertTrue(
+            "os.environ['DJANGO_SETTINGS_MODULE'] = 'project.development"
+            in open(manage, 'r').read())
+
+    def test_create_extra_environment_scripts3(self):
+        entrypoints = ['',
+                       'command=some.package:main',
+                       '']
+        self.recipe.options['script-entrypoints'] = '\n    '.join(
+            entrypoints)
+        manage = os.path.join(self.bin_dir, 'django_env_command')
+        self.recipe.create_extra_environment_scripts([], [])
+        self.assertTrue(os.path.exists(manage))
+
+    def test_create_extra_environment_scripts4(self):
+        entrypoints = ['',
+                       'totally bad line',
+                       '']
+        self.recipe.options['script-entrypoints'] = '\n    '.join(
+            entrypoints)
+        self.assertRaises(
+            UserError,
+            self.recipe.create_extra_environment_scripts,
+            *([], []))
+
 
 class TestTesTRunner(BaseTestRecipe):
 

--- a/src/djangorecipe/tests/tests.py
+++ b/src/djangorecipe/tests/tests.py
@@ -243,13 +243,15 @@ class TestRecipeScripts(BaseTestRecipe):
                         in open(wsgi_script).read())
 
     def test_create_extra_environment_scripts(self):
-        # By default, only gunicorn is configured
+        # Gunicorn is a shorthand.
+        self.recipe.options['script-entrypoints'] = 'gunicorn'
         manage = os.path.join(self.bin_dir, 'django_env_gunicorn')
         self.recipe.create_extra_environment_scripts([], [])
         self.assertTrue(os.path.exists(manage))
 
     def test_create_extra_environment_scripts2(self):
-        # By default, only gunicorn is configured
+        # Gunicorn is a shorthand.
+        self.recipe.options['script-entrypoints'] = 'gunicorn'
         manage = os.path.join(self.bin_dir, 'django_env_gunicorn')
         self.recipe.create_extra_environment_scripts([], [])
         self.assertTrue(
@@ -276,6 +278,11 @@ class TestRecipeScripts(BaseTestRecipe):
             UserError,
             self.recipe.create_extra_environment_scripts,
             *([], []))
+
+    def test_create_extra_environment_scripts5(self):
+        # By default, nothing is generated.
+        result = self.recipe.create_extra_environment_scripts([], [])
+        self.assertEquals([], result)
 
 
 class TestTesTRunner(BaseTestRecipe):


### PR DESCRIPTION
The latest gunicorn doesn't include a `bin/django run_gunicorn` anymore that picks up the correct setting through `bin/django`. You have to run `bin/gunicorn` now.

So... this pull request makes it easy to do this through one extra option. This results in a `bin/django_env_gunicorn` that contains the right settings.