### PR TITLE
Missing 's'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ common settings::
     eggs = ${buildout:eggs}
     project = yourproject
     test = yourproject
-    script-with-settings = gunicorn
+    scripts-with-settings = gunicorn
     # ^^^ This line generates a bin/gunicorn-with-settings script with
     # the correct django environment settings variable already set.
 


### PR DESCRIPTION
It took me ages and some dive to the source code of the recipe in order to realize that there's a missing "S" on the documentation.
